### PR TITLE
Add configurable model downloads and progress UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Run the GUI application:
 ```bash
 python -m src.gui_app
 ```
+
+On first launch you'll be asked to select a directory to store the downloaded
+Demucs/Spleeter models. Separated tracks for each file are written under a
+`stems/` folder inside the chosen output directory.

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+CONFIG_DIR = Path.home() / ".ai_stem_splitter"
+CONFIG_PATH = CONFIG_DIR / "config.json"
+
+class Config:
+    def __init__(self):
+        self.data = {
+            "model_dir": str(CONFIG_DIR / "models"),
+            "output_dir": str(CONFIG_DIR / "output"),
+        }
+        self.load()
+
+    def load(self):
+        if CONFIG_PATH.exists():
+            with open(CONFIG_PATH, "r") as f:
+                try:
+                    self.data.update(json.load(f))
+                except Exception:
+                    pass
+        else:
+            self.save()
+
+    def save(self):
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(self.data, f)
+
+    @property
+    def model_dir(self) -> str:
+        return self.data["model_dir"]
+
+    @model_dir.setter
+    def model_dir(self, path: str) -> None:
+        self.data["model_dir"] = path
+        self.save()
+
+    @property
+    def output_dir(self) -> str:
+        return self.data["output_dir"]
+
+    @output_dir.setter
+    def output_dir(self, path: str) -> None:
+        self.data["output_dir"] = path
+        self.save()


### PR DESCRIPTION
## Summary
- add a simple config module
- allow choosing model and output directories
- save stems in a dedicated `stems/` subfolder
- add progress bar and log window to the GUI
- document new behavior

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68426f6abe5c832ba26347401350bba3