### PR TITLE
Add startup script and project-local model storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,19 @@ package correctly.
 
 ## Usage
 
-Run the GUI application:
+Run the GUI application on any platform:
 
 ```bash
 python -m src.gui_app
 ```
 
+Windows users can also launch the program by double-clicking
+`start_app.bat`.
+
 On first launch you'll be asked to select a directory to store the downloaded
 Demucs/Spleeter models. Separated tracks for each file are written under a
-`stems/` folder inside the chosen output directory. By default the output
-location is `~/.ai_stem_splitter/output/stems`.
+`stems/` folder inside the chosen output directory. By default the models and
+output are stored inside the repository under `models/` and `output/`.
 
 The GUI accepts MP3, WAV, FLAC and OGG files. The application can run entirely
 on the CPU, or it will use the GPU when one is available. It has been tested on

--- a/src/config.py
+++ b/src/config.py
@@ -1,16 +1,22 @@
 import json
 from pathlib import Path
 
-CONFIG_DIR = Path.home() / ".ai_stem_splitter"
-CONFIG_PATH = CONFIG_DIR / "config.json"
+# Store configuration and models inside the project directory so that
+# everything lives under the repository root.  This makes the application
+# portable and avoids writing files to the user's home directory.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = PROJECT_ROOT / "config.json"
 
 class Config:
     def __init__(self):
         self.data = {
-            "model_dir": str(CONFIG_DIR / "models"),
-            "output_dir": str(CONFIG_DIR / "output"),
+            "model_dir": str(PROJECT_ROOT / "models"),
+            "output_dir": str(PROJECT_ROOT / "output"),
         }
         self.load()
+        # Ensure default directories exist
+        Path(self.data["model_dir"]).mkdir(parents=True, exist_ok=True)
+        Path(self.data["output_dir"]).mkdir(parents=True, exist_ok=True)
 
     def load(self):
         if CONFIG_PATH.exists():
@@ -23,7 +29,7 @@ class Config:
             self.save()
 
     def save(self):
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        PROJECT_ROOT.mkdir(parents=True, exist_ok=True)
         with open(CONFIG_PATH, "w") as f:
             json.dump(self.data, f)
 
@@ -34,6 +40,7 @@ class Config:
     @model_dir.setter
     def model_dir(self, path: str) -> None:
         self.data["model_dir"] = path
+        Path(path).mkdir(parents=True, exist_ok=True)
         self.save()
 
     @property
@@ -43,4 +50,5 @@ class Config:
     @output_dir.setter
     def output_dir(self, path: str) -> None:
         self.data["output_dir"] = path
+        Path(path).mkdir(parents=True, exist_ok=True)
         self.save()

--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -132,7 +132,8 @@ class StemGUI(QWidget):
         if model_type == "demucs":
             from demucs.apply import apply_model
             from demucs.pretrained import get_model
-            model = get_model("htdemucs")
+            # Use a lightweight Demucs model by default to keep memory usage low
+            model = get_model("mdx_extra_q")
             apply_model(model, filepath, dest=dest)
         else:
             from spleeter.separator import Separator

--- a/start_app.bat
+++ b/start_app.bat
@@ -1,0 +1,2 @@
+@echo off
+python -m src.gui_app


### PR DESCRIPTION
## Summary
- store config, models and output inside the repository
- add Windows batch script to launch the GUI
- document new startup method and default directories
- use lightweight Demucs model by default

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68426e656b40832b90a90a8afc2bde59