### PR TITLE
Improve Windows launcher and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ python -m src.gui_app
 
 Windows users can also launch the program by double-clicking
 `start_app.bat`.
+Double-clicking the script will create a virtual environment on the first run
+and reuse it on subsequent launches.
 
 On first launch you'll be asked to select a directory to store the downloaded
 Demucs/Spleeter models. Separated tracks for each file are written under a

--- a/start_app.bat
+++ b/start_app.bat
@@ -1,2 +1,10 @@
 @echo off
+setlocal
+
+if not exist "%~dp0venv\Scripts\python.exe" (
+    python -m venv "%~dp0venv"
+    call "%~dp0venv\Scripts\python.exe" -m pip install -r "%~dp0requirements.txt"
+)
+
+call "%~dp0venv\Scripts\activate"
 python -m src.gui_app


### PR DESCRIPTION
## Summary
- create a virtual environment automatically in `start_app.bat`
- document that `start_app.bat` sets up the environment and reuses it

## Testing
- `python -m py_compile src/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684273d2f1a0832bb0d75c5bdfe7f4dd