### PR TITLE
Pin numpy version in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Install Python packages:
 pip install -r requirements.txt
 ```
 
+The requirements file pins `numpy<2`, `spleeter==2.4.2` and
+`tensorflow==2.12.1` for compatibility. If you already have an existing
+environment, recreate it or reinstall the dependencies using the updated
+requirements file.
+
 Run these commands from the repository root so that the GUI can import the
 package correctly.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 torch
 torchaudio
-spleeter
+numpy<2
+spleeter==2.4.2
+tensorflow==2.12.1
 demucs
 PyQt5


### PR DESCRIPTION
## Summary
- pin numpy to <2 for compatibility
- pin related versions of spleeter and tensorflow
- mention these changes in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427701d4c8832b8005a71eb5a1e74a