### PR TITLE
Fix start_app directory initialization

### DIFF
--- a/start_app.bat
+++ b/start_app.bat
@@ -1,5 +1,6 @@
 @echo off
 setlocal
+cd /d "%~dp0"
 
 if not exist "%~dp0venv\Scripts\python.exe" (
     python -m venv "%~dp0venv"
@@ -8,3 +9,4 @@ if not exist "%~dp0venv\Scripts\python.exe" (
 
 call "%~dp0venv\Scripts\activate"
 python -m src.gui_app
+pause


### PR DESCRIPTION
## Summary
- ensure `start_app.bat` changes to its own directory before running
- keep the terminal open after running the app

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684279eab2e8832b93d8858c1f6013d3