### PR TITLE
Handle separation errors in GUI

### DIFF
--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -106,13 +106,22 @@ class StemGUI(QWidget):
 
     def process_files(self, files):
         model_type = self.select_model()
-        for idx, file in enumerate(files, 1):
-            self.log_widget.addItem(f"Processing {Path(file).name}")
-            self.run_separation(file, model_type)
-            self.progress_bar.setValue(idx)
-        QtWidgets.QMessageBox.information(self, "Done", "Processing finished")
-        self.process_btn.setEnabled(True)
-        self.log_widget.addItem("Finished")
+        try:
+            for idx, file in enumerate(files, 1):
+                self.log_widget.addItem(f"Processing {Path(file).name}")
+                try:
+                    self.run_separation(file, model_type)
+                except Exception as e:  # noqa: BLE001
+                    self.log_widget.addItem(
+                        f"Error processing {Path(file).name}: {e}"
+                    )
+                self.progress_bar.setValue(idx)
+            QtWidgets.QMessageBox.information(
+                self, "Done", "Processing finished"
+            )
+        finally:
+            self.process_btn.setEnabled(True)
+            self.log_widget.addItem("Finished")
 
     def select_model(self):
         """Choose model based on available VRAM."""


### PR DESCRIPTION
## Summary
- guard `run_separation` in `process_files` with try/except
- log exceptions to the log widget
- always re-enable the Process button

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68427a9b62e4832b8797b98e8dc63c3f