### PR TITLE
Switch to Demucs-only stem separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # AI-Stem-Splitter
 
-A simple GUI for separating audio stems using Demucs or Spleeter.
+A simple GUI for separating audio stems using Demucs.
 
 ## Requirements
 
-- Python 3.8 or newer
-- Optional CUDA enabled GPU (Demucs is automatically chosen when at least
-  4&nbsp;GB of VRAM are detected)
+- Python 3.10 or newer recommended
+- Optional CUDA enabled GPU for faster processing
 
 
 ## Installation
@@ -17,11 +16,10 @@ Install Python packages:
 pip install -r requirements.txt
 ```
 
-The requirements file pins `numpy<2`, `spleeter==2.4.2`,
-`tensorflow==2.12.1`, `torch==2.2.2` and `torchaudio==2.2.2` for
-compatibility. If you already have an existing
-environment, recreate it or reinstall the dependencies using the updated
-requirements file.
+The requirements file pins `numpy<2`, `torch==2.2.2`,
+`torchaudio==2.2.2` and `diffq` for compatibility with Demucs. If you already have an
+existing environment, recreate it or reinstall the dependencies using the
+updated requirements file.
 
 Run these commands from the repository root so that the GUI can import the
 package correctly.
@@ -40,8 +38,8 @@ Double-clicking the script will create a virtual environment on the first run
 and reuse it on subsequent launches.
 
 On first launch you'll be asked to select a directory to store the downloaded
-Demucs/Spleeter models. Separated tracks for each file are written under a
-`stems/` folder inside the chosen output directory. By default the models and
+Demucs model. Separated tracks for each file are written under a
+`stems/` folder inside the chosen output directory. By default the model and
 output are stored inside the repository under `models/` and `output/`.
 
 The GUI accepts MP3, WAV, FLAC and OGG files. The application can run entirely

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 torch==2.2.2
 torchaudio==2.2.2
 numpy<2
-spleeter==2.4.2
-tensorflow==2.12.1
 demucs
 PyQt5
+diffq

--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -124,30 +124,18 @@ class StemGUI(QWidget):
             self.log_widget.addItem("Finished")
 
     def select_model(self):
-        """Choose model based on available VRAM."""
-        if torch.cuda.is_available():
-            vram = torch.cuda.get_device_properties(0).total_memory / (1024 ** 3)
-        else:
-            vram = 0
-        if vram < 4:
-            return "spleeter"
-        else:
-            return "demucs"
+        """Always use Demucs for separation."""
+        return "demucs"
 
     def run_separation(self, filepath, model_type):
         dest = self._make_dest(filepath)
         os.environ.setdefault("HF_HOME", self.config.model_dir)
         os.environ.setdefault("MODEL_PATH", self.config.model_dir)
-        if model_type == "demucs":
-            from demucs.apply import apply_model
-            from demucs.pretrained import get_model
-            # Use a lightweight Demucs model by default to keep memory usage low
-            model = get_model("mdx_extra_q")
-            apply_model(model, filepath, dest=dest)
-        else:
-            from spleeter.separator import Separator
-            separator = Separator("spleeter:2stems")
-            separator.separate_to_file(filepath, dest)
+        from demucs.apply import apply_model
+        from demucs.pretrained import get_model
+        # Use a lightweight Demucs model by default to keep memory usage low
+        model = get_model("mdx_extra_q")
+        apply_model(model, filepath, dest=dest)
 
     def _make_dest(self, filepath: str) -> str:
         base = Path(filepath).stem

--- a/start_app.bat
+++ b/start_app.bat
@@ -5,6 +5,11 @@ cd /d "%~dp0"
 if not exist "%~dp0venv\Scripts\python.exe" (
     python -m venv "%~dp0venv"
     call "%~dp0venv\Scripts\python.exe" -m pip install -r "%~dp0requirements.txt"
+    if errorlevel 1 (
+        echo Failed to install dependencies.
+        pause
+        exit /b 1
+    )
 )
 
 call "%~dp0venv\Scripts\activate"


### PR DESCRIPTION
## Summary
- drop Spleeter from the codebase
- update requirements and recommend Python 3.10+
- fix README instructions
- abort `start_app.bat` if dependency installation fails
- add diffq to requirements for Demucs

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68427ca03444832baea5c6089deb923a