### PR TITLE
Fix dependency info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ pip install -r requirements.txt
 ```
 
 The requirements file pins `numpy<2`, `torch==2.2.2` and
-`torchaudio==2.2.2` for compatibility with Demucs. If you already have an
-existing environment, recreate it or reinstall the dependencies using the
-updated requirements file.
+`torchaudio==2.2.2` and also installs `diffq` for Demucs models that depend on
+it. If you already have an existing environment, recreate it or reinstall the
+dependencies using the updated requirements file.
 
 Run these commands from the repository root so that the GUI can import the
 package correctly.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ torch==2.2.2
 torchaudio==2.2.2
 numpy<2
 demucs
+diffq
 PyQt5


### PR DESCRIPTION
## Summary
- add `diffq` to requirements
- mention `diffq` in README

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684281b48074832bb8817fe5c7bd2a3e